### PR TITLE
Added possibility to change the download operation count #6

### DIFF
--- a/TOSMBClient/TOSMBSession.h
+++ b/TOSMBClient/TOSMBSession.h
@@ -39,7 +39,11 @@
 
 @property (nonatomic, readonly) NSArray *downloadTasks;
 
-/** 
+/** Defines the number of concurrent download operations. Default:
+ * NSOperationQueueDefaultMaxConcurrentOperationCount. */
+@property (nonatomic) NSInteger maxDownloadOperationCount;
+
+/**
  Creates a new SMB object, but doesn't try to connect until the first request is made.
  For a successful connection, most devices require both the host name and the IP address.
  If only one of these two values is supplied, this library will attempt to resolve the other via
@@ -63,7 +67,7 @@
  */
 - (void)setLoginCredentialsWithUserName:(NSString *)userName password:(NSString *)password;
 
-/** 
+/**
  Performs a synchronous request for a list of files from the network device for the given file path.
  
  @param path The file path to request. Supplying nil or "" will reuest the root list of share folders
@@ -87,8 +91,8 @@
 - (void)cancelAllRequests;
 
 /**
- Creates a download task object for asynchronously downloading a file to disk.
- Only files may be downloaded; folders will return an error.
+ Creates a download task object for asynchronously downloading a file to
+ disk. Only files may be downloaded; folders will return an error.
  
  File downloads are done to the '/tmp' directory and are only copied to the destination when they successfully complete.
  If a file already exists in the destination directory with the same name, then this file's name will be changed before moving.

--- a/TOSMBClient/TOSMBSession.m
+++ b/TOSMBClient/TOSMBSession.m
@@ -88,6 +88,7 @@
 - (instancetype)init
 {
     if (self = [super init]) {
+        _maxDownloadOperationCount = NSOperationQueueDefaultMaxConcurrentOperationCount;
         _session = smb_session_new();
         if (_session == NULL) {
             return nil;
@@ -230,7 +231,7 @@
     }
     
     //If the username or password wasn't supplied, a non-NULL string must still be supplied
-    //to avoid NULL input assertions.   
+    //to avoid NULL input assertions.
     const char *userName = (self.userName ? [self.userName cStringUsingEncoding:NSUTF8StringEncoding] : " ");
     const char *password = (self.password ? [self.password cStringUsingEncoding:NSUTF8StringEncoding] : " ");
     
@@ -426,6 +427,7 @@
         return;
     
     self.downloadsQueue = [[NSOperationQueue alloc] init];
+    self.downloadsQueue.maxConcurrentOperationCount = self.maxDownloadOperationCount;
 }
 
 #pragma mark - String Parsing -
@@ -479,6 +481,13 @@
         return -1;
     
     return smb_session_is_guest(self.session);
+}
+
+- (void)setMaxDownloadOperationCount:(NSInteger)maxDownloadOperationCount
+{
+    _maxDownloadOperationCount = maxDownloadOperationCount;
+    
+    self.downloadsQueue.maxConcurrentOperationCount = maxDownloadOperationCount;
 }
 
 @end


### PR DESCRIPTION
It does not solve the issue, that's rather a workaround. If only one operation at a time is fired, everything should work correctly and without crash. Anyway, it'd be nice to be able to set the maximum operations - eg I prefer to run just 1 at a time.
