### PR TITLE
Crash fix - on_entry_added/removed #9

### DIFF
--- a/TOSMBClient/TONetBIOSNameService.h
+++ b/TOSMBClient/TONetBIOSNameService.h
@@ -32,7 +32,8 @@ typedef void (^TONetBIOSNameServiceDiscoveryEvent)(TONetBIOSNameServiceEntry *en
 
 @interface TONetBIOSNameService : NSObject
 
-@property (nonatomic, readonly) BOOL discovering; /** True when device discovery has been started */
+/** True when device discovery has been started */
+@property (nonatomic, readonly) BOOL discovering;
 
 // -------------------------------------------------------------------------------
 

--- a/TOSMBClient/TONetBIOSNameService.m
+++ b/TOSMBClient/TONetBIOSNameService.m
@@ -55,13 +55,16 @@ const NSTimeInterval kTONetBIOSNameServiceDiscoveryTimeOut = 4.0f;
 static void on_entry_added(void *p_opaque, netbios_ns_entry *entry)
 {
     @autoreleasepool {
-        TONetBIOSNameService *funcSelf = (__bridge TONetBIOSNameService *)(p_opaque);
-        if (funcSelf.discoveryAddedEvent == nil)
+        __weak TONetBIOSNameService *funcSelf = (__bridge TONetBIOSNameService *)(p_opaque);
+        if (funcSelf.discoveryAddedEvent == nil) {
             return;
+        }
         
         TONetBIOSNameServiceEntry *entryObject = [TONetBIOSNameServiceEntry entryWithCEntry:entry];
         dispatch_async(dispatch_get_main_queue(), ^{
-            funcSelf.discoveryAddedEvent(entryObject);
+            if ([funcSelf respondsToSelector:@selector(discoveryAddedEvent)] && funcSelf.discoveryAddedEvent) {
+                funcSelf.discoveryAddedEvent(entryObject);
+            }
         });
     }
 }
@@ -69,13 +72,16 @@ static void on_entry_added(void *p_opaque, netbios_ns_entry *entry)
 static void on_entry_removed(void *p_opaque, netbios_ns_entry *entry)
 {
     @autoreleasepool {
-        TONetBIOSNameService *funcSelf = (__bridge TONetBIOSNameService *)(p_opaque);
-        if (funcSelf.discoveryRemovedEvent == nil)
+        __weak TONetBIOSNameService *funcSelf = (__bridge TONetBIOSNameService *)(p_opaque);
+        if (funcSelf.discoveryRemovedEvent == nil) {
             return;
+        }
         
         TONetBIOSNameServiceEntry *entryObject = [TONetBIOSNameServiceEntry entryWithCEntry:entry];
         dispatch_async(dispatch_get_main_queue(), ^{
-            funcSelf.discoveryRemovedEvent(entryObject);
+            if ([funcSelf respondsToSelector:@selector(discoveryRemovedEvent)] && funcSelf.discoveryRemovedEvent) {
+                funcSelf.discoveryRemovedEvent(entryObject);
+            }
         });
     }
 }


### PR DESCRIPTION
A bit more checking for persistance & object type + weak service. I've did quite a few tests and couldn't make it crash any more, so hopefully it helps.

BTW: I've also moved one comment above the declaration - this way the help works (alt+click).
