### PR TITLE
Crash fix - doubled smb_session_destroy #11

### DIFF
--- a/TOSMBClient/TOSMBSessionDownloadTask.h
+++ b/TOSMBClient/TOSMBSessionDownloadTask.h
@@ -37,7 +37,7 @@
  
  @param downloadTask The download task object calling this delegate method.
  @param destinationPath The absolute file path to the file.
-*/
+ */
 - (void)downloadTask:(TOSMBSessionDownloadTask *)downloadTask didFinishDownloadingToPath:(NSString *)destinationPath;
 
 /**
@@ -50,7 +50,7 @@
  */
 - (void)downloadTask:(TOSMBSessionDownloadTask *)downloadTask
        didWriteBytes:(uint64_t)bytesWritten
-   totalBytesReceived:(uint64_t)totalBytesReceived
+  totalBytesReceived:(uint64_t)totalBytesReceived
 totalBytesExpectedToReceive:(int64_t)totalBytesToReceive;
 
 /**

--- a/TOSMBClient/TOSMBSessionDownloadTask.m
+++ b/TOSMBClient/TOSMBSessionDownloadTask.m
@@ -60,8 +60,8 @@
 @property (assign) smb_session *downloadSession;
 @property (nonatomic, strong) NSBlockOperation *downloadOperation;
 
-@property (assign,readwrite) int64_t countOfBytesReceived;
-@property (assign,readwrite) int64_t countOfBytesExpectedToReceive;
+@property (assign, readwrite) int64_t countOfBytesReceived;
+@property (assign, readwrite) int64_t countOfBytesExpectedToReceive;
 
 @property (nonatomic, assign) UIBackgroundTaskIdentifier backgroundTaskIdentifier;
 
@@ -133,7 +133,13 @@
 
 - (void)dealloc
 {
-    smb_session_destroy(self.downloadSession);
+    // This is called after TOSMBSession dealloc is called, where the smb_session object is released.
+    // As so, probably this part is not required at all, so I'm commenting it out. 
+    // Anyway, even if my assumptions are wrong, we should firstly check if the whole session still exists.
+
+//    if (self.downloadSession && self.session) {
+//        smb_session_destroy(self.downloadSession);
+//    }
 }
 #pragma mark - Temporary Destination Methods -
 - (NSString *)filePathForTemporaryDestination
@@ -245,7 +251,7 @@
 {
     if ([[NSFileManager defaultManager] fileExistsAtPath:self.tempFilePath] == NO)
         return NO;
-
+    
     NSDate *modificationTime = [[[NSFileManager defaultManager] attributesOfItemAtPath:self.tempFilePath error:nil] fileModificationDate];
     if ([modificationTime isEqual:self.file.modificationTime] == NO) {
         return NO;
@@ -327,7 +333,7 @@
     operation.completionBlock = ^{
         weakSelf.downloadOperation = nil;
     };
-
+    
     self.downloadOperation = operation;
 }
 
@@ -346,7 +352,7 @@
         //Release the background task handler, making the app eligible to be suspended now
         if (self.backgroundTaskIdentifier)
             [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTaskIdentifier];
-            
+        
         if (self.downloadSession && treeID)
             smb_tree_disconnect(self.downloadSession, treeID);
         


### PR DESCRIPTION
Basically, I've commented out the destroy in dealloc. It was anyway called in session object, so here we were trying to destroy already destroyed object. You should have a closer look into this PR, because I'm not sure whether there are situations where session does not destroy smb session (what would result with a zombie). After changing this I did not receive any more crashes connected with double destroying. I didn't check it with the Instruments nor for zombies.
