### PR TITLE
Fixed writing data to disk.

### DIFF
--- a/TOSMBClient/TOSMBSessionDownloadTask.m
+++ b/TOSMBClient/TOSMBSessionDownloadTask.m
@@ -483,7 +483,7 @@
         
         //Save them to the file handle (And ensure the NSData object is flushed immediately)
         @autoreleasepool {
-            [fileHandle writeData:[NSData dataWithBytes:buffer length:bufferSize]];
+            [fileHandle writeData:[NSData dataWithBytes:buffer length:bytesRead]];
         }
         
         //Ensure the data is properly written to disk before proceeding


### PR DESCRIPTION
To avoid problems with small files and last chunk of large files, to
disk should be save exact count of bytes that was read from smb.
