### PR TITLE
Fix session attempt connection's error check.

### DIFF
--- a/TOSMBClient/TOSMBSession.m
+++ b/TOSMBClient/TOSMBSession.m
@@ -170,7 +170,7 @@
 {
     __block NSError *error = nil;
     dispatch_sync(self.serialQueue, ^{
-        [self attemptConnectionWithSessionPointer:self.session];
+        error = [self attemptConnectionWithSessionPointer:self.session];
     });
         
     if (error)


### PR DESCRIPTION
I found a attemptConnection bug.
"attemptConnectionWithSessionPointer" return value is not checked.
