### PR TITLE
#26 Crash fix when SMB device suddenly doesn't respond"

### DIFF
--- a/TOSMBClient/TOSMBConstants.h
+++ b/TOSMBClient/TOSMBConstants.h
@@ -35,6 +35,7 @@ typedef NS_ENUM(NSInteger, TOSMBSessionErrorCode)
     TOSMBSessionErrorCodeShareConnectionFailed = 1004,              /* Connection attempt to a share in the device failed. */
     TOSMBSessionErrorCodeFileNotFound = 1005,                       /* Unable to locate the requested file. */
     TOSMBSessionErrorCodeDirectoryDownloaded = 1006,                /* A directory was attempted to be downloaded. */
+    TOSMBSessionErrorCodeFileDownloadFailed = 1007,                /* The file could not be downloaded, possible network error. */
 
 };
 
@@ -52,7 +53,8 @@ typedef NS_ENUM(NSInteger, TOSMBSessionDownloadTaskState) {
     TOSMBSessionDownloadTaskStateRunning,
     TOSMBSessionDownloadTaskStateSuspended,
     TOSMBSessionDownloadTaskStateCancelled,
-    TOSMBSessionDownloadTaskStateCompleted
+    TOSMBSessionDownloadTaskStateCompleted,
+    TOSMBSessionDownloadTaskStateFailed
 };
 
 extern TONetBIOSNameServiceType TONetBIOSNameServiceTypeForCType(char type);

--- a/TOSMBClient/TOSMBConstants.m
+++ b/TOSMBClient/TOSMBConstants.m
@@ -70,6 +70,9 @@ NSString *localizedStringForErrorCode(TOSMBSessionErrorCode errorCode)
         case TOSMBSessionErrorCodeDirectoryDownloaded:
             errorMessage = @"Unable to download a directory.";
             break;
+        case TOSMBSessionErrorCodeFileDownloadFailed:
+            errorMessage = @"File download failed - check your connection.";
+            break;
         case TOSMBSessionErrorCodeUnknown:
         default:
             errorMessage = @"Unknown Error Occurred.";

--- a/TOSMBClient/TOSMBSession.m
+++ b/TOSMBClient/TOSMBSession.m
@@ -238,8 +238,8 @@
     
     //If the username or password wasn't supplied, a non-NULL string must still be supplied
     //to avoid NULL input assertions.
-    const char *userName = (self.userName ? [self.userName cStringUsingEncoding:NSUTF8StringEncoding] : " ");
-    const char *password = (self.password ? [self.password cStringUsingEncoding:NSUTF8StringEncoding] : " ");
+    const char *userName = (self.userName ? [self.userName cStringUsingEncoding:NSUTF8StringEncoding] : "admin");
+    const char *password = (self.password ? [self.password cStringUsingEncoding:NSUTF8StringEncoding] : "");
     
     //Attempt a login. Even if we're downgraded to guest, the login call will succeed
     smb_session_set_creds(session, hostName, userName, password);

--- a/TOSMBClient/TOSMBSession.m
+++ b/TOSMBClient/TOSMBSession.m
@@ -238,8 +238,8 @@
     
     //If the username or password wasn't supplied, a non-NULL string must still be supplied
     //to avoid NULL input assertions.
-    const char *userName = (self.userName ? [self.userName cStringUsingEncoding:NSUTF8StringEncoding] : "admin");
-    const char *password = (self.password ? [self.password cStringUsingEncoding:NSUTF8StringEncoding] : "");
+    const char *userName = (self.userName ? [self.userName cStringUsingEncoding:NSUTF8StringEncoding] : " ");
+    const char *password = (self.password ? [self.password cStringUsingEncoding:NSUTF8StringEncoding] : " ");
     
     //Attempt a login. Even if we're downgraded to guest, the login call will succeed
     smb_session_set_creds(session, hostName, userName, password);

--- a/TOSMBClient/TOSMBSessionDownloadTask.m
+++ b/TOSMBClient/TOSMBSessionDownloadTask.m
@@ -362,8 +362,10 @@
     void (^cleanup)(void) = ^{
         
         //Release the background task handler, making the app eligible to be suspended now
-        if (self.backgroundTaskIdentifier)
+        if (self.backgroundTaskIdentifier) {
             [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTaskIdentifier];
+            self.backgroundTaskIdentifier = 0;
+        }
         
         if (self.downloadSession && treeID)
             smb_tree_disconnect(self.downloadSession, treeID);
@@ -494,7 +496,6 @@
         if (bytesRead < 0) {
             [self fail];
             [self didFailWithError:errorForErrorCode(TOSMBSessionErrorCodeFileDownloadFailed)];
-            cleanup();
             break;
         }
         

--- a/TOSMBClientExample/TOAppDelegate.h
+++ b/TOSMBClientExample/TOAppDelegate.h
@@ -12,6 +12,4 @@
 
 @property (strong, nonatomic) UIWindow *window;
 
-
 @end
-

--- a/TOSMBClientExample/TOFilesTableViewController.m
+++ b/TOSMBClientExample/TOFilesTableViewController.m
@@ -35,17 +35,11 @@
     self.navigationItem.title = @"Loading...";
 }
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
-}
-
 #pragma mark - Table view data source
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     return self.files.count;
 }
-
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     static NSString *identifier = @"Cell";

--- a/TOSMBClientExample/TORootTableViewController.h
+++ b/TOSMBClientExample/TORootTableViewController.h
@@ -15,4 +15,3 @@
 @property (nonatomic, weak) TORootViewController *rootController;
 
 @end
-


### PR DESCRIPTION
Fixes #26 .

The crash responsible line was TOSMBClient/TOSMBSessionDownloadTask.m L:476. Because there was unsigned integer it took wrong value from `smb_fread` when the error occured (it returns `-1` then). Now it's signed, we're checking if that's `-1` and if so, we're breaking further communication and failing whole download (the file would be malformed anyway). I also made a small refactor and divided the controller into pragma marks, so it is easier to read.
