### PR TITLE
Fixed cancelAllRequests to also cancel file downloads

### DIFF
--- a/TOSMBClient/TOSMBSession.m
+++ b/TOSMBClient/TOSMBSession.m
@@ -392,6 +392,7 @@
 - (void)cancelAllRequests
 {
     [self.dataQueue cancelAllOperations];
+    [self.downloadsQueue cancelAllOperations];
 }
 
 #pragma mark - Download Tasks -


### PR DESCRIPTION
When calling cancelAllRequests() on my session object, the files in the downloadsQueue would not get canceled. Added a line to fix this.
