### PR TITLE
Fixed crash on adding nil dependency to an operation.

### DIFF
--- a/TOSMBClient/TOSMBSessionDownloadTask.m
+++ b/TOSMBClient/TOSMBSessionDownloadTask.m
@@ -238,7 +238,9 @@
     
     NSBlockOperation *deleteOperation = [[NSBlockOperation alloc] init];
     [deleteOperation addExecutionBlock:deleteBlock];
-    [deleteOperation addDependency:self.downloadOperation];
+    if (self.downloadOperation) { // if the download operation doesn't exist, we can delete file even immediately
+        [deleteOperation addDependency:self.downloadOperation];
+    }
     [self.session.downloadsQueue addOperation:deleteOperation];
     
     [self.downloadOperation cancel];


### PR DESCRIPTION
I found a crash when adding to delete operation a dependency of download operation (== nil). This commit resolves the issue. If the downloadOperation == nil we can delete the file immediately anyway, because we have nothing to wait for.
