### PR TITLE
Add login prompt on auth error

### DIFF
--- a/TOSMBClient/TOSMBConstants.h
+++ b/TOSMBClient/TOSMBConstants.h
@@ -22,6 +22,8 @@
 
 #import <Foundation/Foundation.h>
 
+extern NSString * const TOSMBClientErrorDomain;
+
 /** SMB Error Values */
 typedef NS_ENUM(NSInteger, TOSMBSessionErrorCode)
 {

--- a/TOSMBClient/TOSMBConstants.m
+++ b/TOSMBClient/TOSMBConstants.m
@@ -24,6 +24,8 @@
 #import "netbios_defs.h"
 #import "smb_defs.h"
 
+NSString * const TOSMBClientErrorDomain = @"TOSMBClient";
+
 TONetBIOSNameServiceType TONetBIOSNameServiceTypeForCType(char type)
 {
     switch (type) {


### PR DESCRIPTION
This commit upgrades the error alerts in the example application
to `UIAlertControllers` and provides an alert controller which
prompts the user for their SMB login creds.