### PR TITLE
Persist session to avoid reauth

### DIFF
--- a/TOSMBClient/TOSMBSession.m
+++ b/TOSMBClient/TOSMBSession.m
@@ -203,8 +203,10 @@
     }
     
     //Don't attempt another connection if we already made it through
-    if (smb_session_is_guest(session) >= 0)
+    if (smb_session_is_guest(session) >= 0) {
+        self.connected = YES;
         return nil;
+    }
     
     //Ensure at least one piece of connection information was supplied
     if (self.ipAddress.length == 0 && self.hostName.length == 0) {

--- a/TOSMBClientExample/TORootTableViewController.h
+++ b/TOSMBClientExample/TORootTableViewController.h
@@ -12,6 +12,7 @@
 
 @interface TORootTableViewController : UITableViewController
 
-@property (nonatomic, weak) TORootViewController *rootController;
+@property (nonatomic, weak, nullable) TORootViewController *rootController;
+@property (nonatomic, strong, null_resettable) TOSMBSession *session;
 
 @end

--- a/TOSMBClientExample/TORootViewController.h
+++ b/TOSMBClientExample/TORootViewController.h
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class TOSMBSession;
 
 @interface TORootViewController : UIViewController
@@ -20,9 +22,13 @@
 @property (nonatomic, weak) IBOutlet UIButton *suspendButton;
 @property (nonatomic, weak) IBOutlet UIButton *cancelButton;
 
+@property (nonatomic, strong, null_resettable) TOSMBSession *session;
+
 - (IBAction)suspendButtonTapped:(id)sender;
 - (IBAction)cancelButtonTapped:(id)sender;
 
 - (void)downloadFileFromSession:(TOSMBSession *)session atFilePath:(NSString *)filePath;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/TOSMBClientExample/TORootViewController.m
+++ b/TOSMBClientExample/TORootViewController.m
@@ -15,7 +15,6 @@
 
 @property (nonatomic, strong) UIDocumentInteractionController *docController;
 
-@property (nonatomic, strong) TOSMBSession *downloadSession;
 @property (nonatomic, strong) TOSMBSessionDownloadTask *downloadTask;
 
 @property (nonatomic, strong) NSString *filePath;
@@ -23,6 +22,15 @@
 @end
 
 @implementation TORootViewController
+
+#pragma mark - Properties
+
+- (TOSMBSession *)session {
+    if (!_session) {
+        _session = [[TOSMBSession alloc] init];
+    }
+    return _session;
+}
 
 #pragma mark - View Lifecycle
 
@@ -42,6 +50,7 @@
     UINavigationController *controller = [[UINavigationController alloc] initWithRootViewController:tableController];
     controller.modalPresentationStyle = UIModalPresentationFormSheet;
     tableController.rootController = self;
+    tableController.session = self.session;
     [self presentViewController:controller animated:YES completion:nil];
     
     UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(modalCancelButtonTapped:)];
@@ -96,7 +105,7 @@
     self.suspendButton.hidden = NO;
     self.progressView.alpha = 1.0f;
     
-    self.downloadSession = session;
+    self.session = session;
     self.downloadTask = [session downloadTaskForFileAtPath:filePath destinationPath:nil delegate:self];
     
     [self dismissViewControllerAnimated:YES completion:^{


### PR DESCRIPTION
This commit:
 * Exposes the session property on `TORootViewController`.
 * Exposes the session property on `TORootTableViewController`.
 * Lazy loads the session properties on `TORootViewController`
   and `TORootTableViewController` to allow them to be easily
   resettable.
 * Resets the session if the user cancels an auth challenge
   or selects a new host.
 * Automatically pushes a `TOFilesTableViewController` if an
   instance of `TORootTableViewController`'s session
   is connected.
 * Fixes an issue with `-connected` on `TOSMBSession`
   where a session was already connected without creds
   and a successful reattempt is made.
 * Sets the password field as a secure text entry.