### PR TITLE
Upload task

### DIFF
--- a/TOSMBClient.xcodeproj/project.pbxproj
+++ b/TOSMBClient.xcodeproj/project.pbxproj
@@ -68,6 +68,10 @@
 		22CB5AEB1B78929B006F05F2 /* TORootViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 22CB5AEA1B78929B006F05F2 /* TORootViewController.m */; };
 		22FA84951DC098B700634DB7 /* TONetBIOSNameServiceEntryPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 22FA84931DC098B700634DB7 /* TONetBIOSNameServiceEntryPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		22FA849A1DC0996900634DB7 /* TOSMBSessionFilePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 22FA84981DC0996900634DB7 /* TOSMBSessionFilePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E82FE0301DD91955008E82FA /* TOSMBSessionTask.h in Headers */ = {isa = PBXBuildFile; fileRef = E82FE02E1DD91955008E82FA /* TOSMBSessionTask.h */; };
+		E82FE0311DD91955008E82FA /* TOSMBSessionTask.m in Sources */ = {isa = PBXBuildFile; fileRef = E82FE02F1DD91955008E82FA /* TOSMBSessionTask.m */; };
+		E8431A081DCD53DD0007BCFA /* TOSMBSessionUploadTask.h in Headers */ = {isa = PBXBuildFile; fileRef = E8431A061DCD53DD0007BCFA /* TOSMBSessionUploadTask.h */; };
+		E8431A091DCD53DD0007BCFA /* TOSMBSessionUploadTask.m in Sources */ = {isa = PBXBuildFile; fileRef = E8431A071DCD53DD0007BCFA /* TOSMBSessionUploadTask.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -129,6 +133,14 @@
 		22CB5AEA1B78929B006F05F2 /* TORootViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TORootViewController.m; sourceTree = "<group>"; };
 		22FA84931DC098B700634DB7 /* TONetBIOSNameServiceEntryPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TONetBIOSNameServiceEntryPrivate.h; sourceTree = "<group>"; };
 		22FA84981DC0996900634DB7 /* TOSMBSessionFilePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TOSMBSessionFilePrivate.h; sourceTree = "<group>"; };
+		E82FE02E1DD91955008E82FA /* TOSMBSessionTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TOSMBSessionTask.h; sourceTree = "<group>"; };
+		E82FE02F1DD91955008E82FA /* TOSMBSessionTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TOSMBSessionTask.m; sourceTree = "<group>"; };
+		E82FE0321DD91C46008E82FA /* TOSMBSessionTaskPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TOSMBSessionTaskPrivate.h; sourceTree = "<group>"; };
+		E82FE0331DD920E1008E82FA /* TOSMBSessionPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TOSMBSessionPrivate.h; sourceTree = "<group>"; };
+		E82FE0341DD930CD008E82FA /* TOSMBSessionDownloadTaskPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TOSMBSessionDownloadTaskPrivate.h; sourceTree = "<group>"; };
+		E82FE0351DD930DA008E82FA /* TOSMBSessionUploadTaskPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TOSMBSessionUploadTaskPrivate.h; sourceTree = "<group>"; };
+		E8431A061DCD53DD0007BCFA /* TOSMBSessionUploadTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TOSMBSessionUploadTask.h; sourceTree = "<group>"; };
+		E8431A071DCD53DD0007BCFA /* TOSMBSessionUploadTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TOSMBSessionUploadTask.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -242,11 +254,19 @@
 				22FA84931DC098B700634DB7 /* TONetBIOSNameServiceEntryPrivate.h */,
 				22236CF71B67C2C700176C34 /* TOSMBSession.h */,
 				22236CF81B67C2C700176C34 /* TOSMBSession.m */,
+				E82FE0331DD920E1008E82FA /* TOSMBSessionPrivate.h */,
 				22301F6E1B6DED2500326F84 /* TOSMBSessionFile.h */,
 				22301F6F1B6DED2500326F84 /* TOSMBSessionFile.m */,
 				22FA84981DC0996900634DB7 /* TOSMBSessionFilePrivate.h */,
+				E82FE02E1DD91955008E82FA /* TOSMBSessionTask.h */,
+				E82FE02F1DD91955008E82FA /* TOSMBSessionTask.m */,
+				E82FE0321DD91C46008E82FA /* TOSMBSessionTaskPrivate.h */,
 				22AE8B861B6F66E4008412CF /* TOSMBSessionDownloadTask.h */,
 				22AE8B871B6F66E4008412CF /* TOSMBSessionDownloadTask.m */,
+				E82FE0341DD930CD008E82FA /* TOSMBSessionDownloadTaskPrivate.h */,
+				E8431A061DCD53DD0007BCFA /* TOSMBSessionUploadTask.h */,
+				E8431A071DCD53DD0007BCFA /* TOSMBSessionUploadTask.m */,
+				E82FE0351DD930DA008E82FA /* TOSMBSessionUploadTaskPrivate.h */,
 			);
 			path = TOSMBClient;
 			sourceTree = "<group>";
@@ -296,6 +316,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E8431A081DCD53DD0007BCFA /* TOSMBSessionUploadTask.h in Headers */,
 				227D6F4C1CBD4EF4000E8A78 /* TOSMBClient.h in Headers */,
 				227D6F241CBD4ACA000E8A78 /* TOSMBConstants.h in Headers */,
 				229EC87D1CF3240B0007FE4A /* smb_session.h in Headers */,
@@ -311,6 +332,7 @@
 				229EC87C1CF3240B0007FE4A /* smb_file.h in Headers */,
 				227D6F251CBD4ACA000E8A78 /* TONetBIOSNameService.h in Headers */,
 				227D6F261CBD4ACA000E8A78 /* TONetBIOSNameServiceEntry.h in Headers */,
+				E82FE0301DD91955008E82FA /* TOSMBSessionTask.h in Headers */,
 				227D6F271CBD4ACA000E8A78 /* TOSMBSession.h in Headers */,
 				22FA84951DC098B700634DB7 /* TONetBIOSNameServiceEntryPrivate.h in Headers */,
 				22FA849A1DC0996900634DB7 /* TOSMBSessionFilePrivate.h in Headers */,
@@ -497,8 +519,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				224899531DC0A642006CA7B3 /* TOSMBConstants.m in Sources */,
+				E82FE0311DD91955008E82FA /* TOSMBSessionTask.m in Sources */,
 				224899551DC0A642006CA7B3 /* TONetBIOSNameService.m in Sources */,
 				224899571DC0A642006CA7B3 /* TONetBIOSNameServiceEntry.m in Sources */,
+				E8431A091DCD53DD0007BCFA /* TOSMBSessionUploadTask.m in Sources */,
 				2248995B1DC0A642006CA7B3 /* TOSMBSession.m in Sources */,
 				2248995D1DC0A642006CA7B3 /* TOSMBSessionFile.m in Sources */,
 				224899611DC0A642006CA7B3 /* TOSMBSessionDownloadTask.m in Sources */,
@@ -811,6 +835,7 @@
 				22F243FF1DC0AD4900ED6395 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/TOSMBClient.xcodeproj/project.pbxproj
+++ b/TOSMBClient.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 		22FA849A1DC0996900634DB7 /* TOSMBSessionFilePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 22FA84981DC0996900634DB7 /* TOSMBSessionFilePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E82FE0301DD91955008E82FA /* TOSMBSessionTask.h in Headers */ = {isa = PBXBuildFile; fileRef = E82FE02E1DD91955008E82FA /* TOSMBSessionTask.h */; };
 		E82FE0311DD91955008E82FA /* TOSMBSessionTask.m in Sources */ = {isa = PBXBuildFile; fileRef = E82FE02F1DD91955008E82FA /* TOSMBSessionTask.m */; };
+		E842C6BE1DDA48040017A7AD /* TOSMBSessionTask.m in Sources */ = {isa = PBXBuildFile; fileRef = E82FE02F1DD91955008E82FA /* TOSMBSessionTask.m */; };
+		E842C6BF1DDA480B0017A7AD /* TOSMBSessionUploadTask.m in Sources */ = {isa = PBXBuildFile; fileRef = E8431A071DCD53DD0007BCFA /* TOSMBSessionUploadTask.m */; };
 		E8431A081DCD53DD0007BCFA /* TOSMBSessionUploadTask.h in Headers */ = {isa = PBXBuildFile; fileRef = E8431A061DCD53DD0007BCFA /* TOSMBSessionUploadTask.h */; };
 		E8431A091DCD53DD0007BCFA /* TOSMBSessionUploadTask.m in Sources */ = {isa = PBXBuildFile; fileRef = E8431A071DCD53DD0007BCFA /* TOSMBSessionUploadTask.m */; };
 /* End PBXBuildFile section */
@@ -497,10 +499,12 @@
 				2214DCF61B666766003E3EF1 /* TONetBIOSNameService.m in Sources */,
 				2214DCC51B661CD2003E3EF1 /* TOAppDelegate.m in Sources */,
 				22301F701B6DED2500326F84 /* TOSMBSessionFile.m in Sources */,
+				E842C6BE1DDA48040017A7AD /* TOSMBSessionTask.m in Sources */,
 				22AE8B881B6F66E4008412CF /* TOSMBSessionDownloadTask.m in Sources */,
 				22236CF91B67C2C700176C34 /* TOSMBSession.m in Sources */,
 				2214DCC21B661CD2003E3EF1 /* main.m in Sources */,
 				2214DCF91B6678C8003E3EF1 /* TONetBIOSNameServiceEntry.m in Sources */,
+				E842C6BF1DDA480B0017A7AD /* TOSMBSessionUploadTask.m in Sources */,
 				22CB5AEB1B78929B006F05F2 /* TORootViewController.m in Sources */,
 				2214DCFC1B66847B003E3EF1 /* TOSMBConstants.m in Sources */,
 			);

--- a/TOSMBClient.xcodeproj/xcshareddata/xcschemes/TOSMBClientExample.xcscheme
+++ b/TOSMBClient.xcodeproj/xcshareddata/xcschemes/TOSMBClientExample.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2214DCD41B661CD2003E3EF1"
+               BuildableName = "TOSMBClientExampleTests.xctest"
+               BlueprintName = "TOSMBClientExampleTests"
+               ReferencedContainer = "container:TOSMBClient.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/TOSMBClient/TOSMBConstants.h
+++ b/TOSMBClient/TOSMBConstants.h
@@ -55,6 +55,16 @@ typedef NS_ENUM(NSInteger, TOSMBSessionDownloadTaskState) {
     TOSMBSessionDownloadTaskStateFailed
 };
 
+/** SMB Connection State */
+typedef NS_ENUM(NSUInteger, TOSMBSessionTaskState) {
+    TOSMBSessionTaskStateReady,
+    TOSMBSessionTaskStateRunning,
+    TOSMBSessionTaskStateSuspended,
+    TOSMBSessionTaskStateCancelled,
+    TOSMBSessionTaskStateCompleted,
+    TOSMBSessionTaskStateFailed
+};
+
 extern TONetBIOSNameServiceType TONetBIOSNameServiceTypeForCType(char type);
 extern char TONetBIOSNameServiceCTypeForType(char type);
 

--- a/TOSMBClient/TOSMBConstants.h
+++ b/TOSMBClient/TOSMBConstants.h
@@ -53,7 +53,7 @@ typedef NS_ENUM(NSInteger, TOSMBSessionDownloadTaskState) {
     TOSMBSessionDownloadTaskStateCancelled,
     TOSMBSessionDownloadTaskStateCompleted,
     TOSMBSessionDownloadTaskStateFailed
-};
+} __deprecated_enum_msg("Use TOSMBSessionTaskState values instead");
 
 /** SMB Connection State */
 typedef NS_ENUM(NSUInteger, TOSMBSessionTaskState) {

--- a/TOSMBClient/TOSMBSession.h
+++ b/TOSMBClient/TOSMBSession.h
@@ -42,6 +42,9 @@
 @property (nonatomic, readonly) NSArray <TOSMBSessionDownloadTask *> *downloadTasks;
 @property (nonatomic, readonly) NSArray <TOSMBSessionUploadTask *> *uploadTasks;
 
+@property (nonatomic, readonly) dispatch_queue_t serialQueue;
+@property (nonatomic, readonly) NSOperationQueue *taskQueue;
+
 /** Defines the number of concurrent download operations. Default:
  * NSOperationQueueDefaultMaxConcurrentOperationCount. */
 @property (nonatomic) NSInteger maxDownloadOperationCount;
@@ -129,15 +132,15 @@
 /**
  Creates an upload task object for asynchronously uploading a file to disk.
  
+ @param path The destination path (Either just the directory, or even a new name) for this file.
  @param data The path on the SMB device for the file to download.
- @param destinationPath The destination path (Either just the directory, or even a new name) for this file.
  @param completionHandler A block called once the download has completed.
  @param failHandler A block called if the download fails
  
  @return An upload task object ready to be started, or nil upon failure.
  */
 - (TOSMBSessionUploadTask *)uploadTaskForFileAtPath:(NSString *)path
-                                               Data:(NSData *)data
+                                               data:(NSData *)data
                                   completionHandler:(void (^)())completionHandler
                                         failHandler:(void (^)(NSError *error))failHandler;
 

--- a/TOSMBClient/TOSMBSession.h
+++ b/TOSMBClient/TOSMBSession.h
@@ -24,6 +24,8 @@
 #import "TOSMBConstants.h"
 
 @class TOSMBSessionDownloadTask;
+@class TOSMBSessionUploadTask;
+
 @protocol TOSMBSessionDownloadTaskDelegate;
 
 @interface TOSMBSession : NSObject
@@ -37,7 +39,8 @@
 @property (nonatomic, readonly) BOOL connected;
 @property (nonatomic, readonly) NSInteger guest;
 
-@property (nonatomic, readonly) NSArray *downloadTasks;
+@property (nonatomic, readonly) NSArray <TOSMBSessionDownloadTask *> *downloadTasks;
+@property (nonatomic, readonly) NSArray <TOSMBSessionUploadTask *> *uploadTasks;
 
 /** Defines the number of concurrent download operations. Default:
  * NSOperationQueueDefaultMaxConcurrentOperationCount. */
@@ -123,5 +126,19 @@
                                         progressHandler:(void (^)(uint64_t totalBytesWritten, uint64_t totalBytesExpected))progressHandler
                                       completionHandler:(void (^)(NSString *filePath))completionHandler
                                             failHandler:(void (^)(NSError *error))error;
+/**
+ Creates an upload task object for asynchronously uploading a file to disk.
+ 
+ @param data The path on the SMB device for the file to download.
+ @param destinationPath The destination path (Either just the directory, or even a new name) for this file.
+ @param completionHandler A block called once the download has completed.
+ @param failHandler A block called if the download fails
+ 
+ @return An upload task object ready to be started, or nil upon failure.
+ */
+- (TOSMBSessionUploadTask *)uploadTaskForData:(NSData *)data
+                              destinationPath:(NSString *)destinationPath
+                            completionHandler:(void (^)())completionHandler
+                                  failHandler:(void (^)(NSError *error))error;
 
 @end

--- a/TOSMBClient/TOSMBSession.h
+++ b/TOSMBClient/TOSMBSession.h
@@ -125,7 +125,7 @@
                                         destinationPath:(NSString *)destinationPath
                                         progressHandler:(void (^)(uint64_t totalBytesWritten, uint64_t totalBytesExpected))progressHandler
                                       completionHandler:(void (^)(NSString *filePath))completionHandler
-                                            failHandler:(void (^)(NSError *error))error;
+                                            failHandler:(void (^)(NSError *error))failHandler;
 /**
  Creates an upload task object for asynchronously uploading a file to disk.
  
@@ -136,9 +136,9 @@
  
  @return An upload task object ready to be started, or nil upon failure.
  */
-- (TOSMBSessionUploadTask *)uploadTaskForData:(NSData *)data
-                              destinationPath:(NSString *)destinationPath
-                            completionHandler:(void (^)())completionHandler
-                                  failHandler:(void (^)(NSError *error))error;
+- (TOSMBSessionUploadTask *)uploadTaskForFileAtPath:(NSString *)path
+                                               Data:(NSData *)data
+                                  completionHandler:(void (^)())completionHandler
+                                        failHandler:(void (^)(NSError *error))failHandler;
 
 @end

--- a/TOSMBClient/TOSMBSession.h
+++ b/TOSMBClient/TOSMBSession.h
@@ -141,6 +141,7 @@
  */
 - (TOSMBSessionUploadTask *)uploadTaskForFileAtPath:(NSString *)path
                                                data:(NSData *)data
+                                    progressHandler:(void (^)(uint64_t totalBytesWritten, uint64_t totalBytesExpected))progressHandler
                                   completionHandler:(void (^)())completionHandler
                                         failHandler:(void (^)(NSError *error))failHandler;
 

--- a/TOSMBClient/TOSMBSession.h
+++ b/TOSMBClient/TOSMBSession.h
@@ -45,9 +45,9 @@
 @property (nonatomic, readonly) dispatch_queue_t serialQueue;
 @property (nonatomic, readonly) NSOperationQueue *taskQueue;
 
-/** Defines the number of concurrent download operations. Default:
+/** Defines the number of concurrent task operations. Default:
  * NSOperationQueueDefaultMaxConcurrentOperationCount. */
-@property (nonatomic) NSInteger maxDownloadOperationCount;
+@property (nonatomic) NSInteger maxTaskOperationCount;
 
 /**
  Creates a new SMB object, but doesn't try to connect until the first request is made.
@@ -143,5 +143,11 @@
                                                data:(NSData *)data
                                   completionHandler:(void (^)())completionHandler
                                         failHandler:(void (^)(NSError *error))failHandler;
+
+@end
+
+@interface TOSMBSession (Deprecated)
+
+@property (nonatomic) NSInteger maxDownloadOperationCount __deprecated_msg("Use maxTaskOperationCount instead");
 
 @end

--- a/TOSMBClient/TOSMBSession.m
+++ b/TOSMBClient/TOSMBSession.m
@@ -395,10 +395,11 @@
 }
 
 #pragma mark - Upload Tasks -
-- (TOSMBSessionUploadTask *)uploadTaskForFileAtPath:(NSString *)path data:(NSData *)data completionHandler:(void (^)())completionHandler failHandler:(void (^)(NSError *error))failHandler {
+- (TOSMBSessionUploadTask *)uploadTaskForFileAtPath:(NSString *)path data:(NSData *)data progressHandler:(void (^)(uint64_t, uint64_t))progressHandler completionHandler:(void (^)())completionHandler failHandler:(void (^)(NSError *))failHandler {
     TOSMBSessionUploadTask *task = [[TOSMBSessionUploadTask alloc] initWithSession:self
                                                                               path:path
                                                                               data:data
+                                                                   progressHandler:progressHandler
                                                                     successHandler:completionHandler
                                                                        failHandler:failHandler];
     

--- a/TOSMBClient/TOSMBSession.m
+++ b/TOSMBClient/TOSMBSession.m
@@ -405,13 +405,17 @@
 
 #pragma mark - Upload Tasks -
 
-- (TOSMBSessionUploadTask *)uploadTaskForData:(NSData *)data
-                              destinationPath:(NSString *)destinationPath
-                            completionHandler:(void (^)())completionHandler
-                                  failHandler:(void (^)(NSError *error))error {
+- (TOSMBSessionUploadTask *)uploadTaskForFileAtPath:(NSString *)path
+                                               Data:(NSData *)data
+                                  completionHandler:(void (^)())completionHandler
+                                        failHandler:(void (^)(NSError *error))failHandler {
     [self setupDownloadQueue];
     
-    TOSMBSessionUploadTask *task = [[TOSMBSessionUploadTask alloc] init];
+    TOSMBSessionUploadTask *task = [[TOSMBSessionUploadTask alloc] initWithSession:self
+                                                                              path:path
+                                                                              data:data
+                                                                    successHandler:completionHandler
+                                                                       failHandler:failHandler];
     
     self.uploadTasks = [self.uploadTasks ?: @[] arrayByAddingObject:task];
     

--- a/TOSMBClient/TOSMBSessionDownloadTask.h
+++ b/TOSMBClient/TOSMBSessionDownloadTask.h
@@ -26,7 +26,7 @@
 @class TOSMBSession;
 @class TOSMBSessionDownloadTask;
 
-@protocol TOSMBSessionDownloadTaskDelegate <NSObject>
+@protocol TOSMBSessionDownloadTaskDelegate <TOSMBSessionTaskDelegate>
 
 @optional
 
@@ -70,7 +70,7 @@ totalBytesExpectedToReceive:(uint64_t)totalBytesToReceive;
  @param downloadTask The download task object calling this delegate method.
  @param error The error describing why the task failed.
  */
-- (void)downloadTask:(TOSMBSessionDownloadTask *)downloadTask didCompleteWithError:(NSError *)error;
+- (void)downloadTask:(TOSMBSessionDownloadTask *)downloadTask didCompleteWithError:(NSError *)error __deprecated_msg("See -task:didCompleteWithError:");
 
 @end
 

--- a/TOSMBClient/TOSMBSessionDownloadTask.h
+++ b/TOSMBClient/TOSMBSessionDownloadTask.h
@@ -20,7 +20,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // -------------------------------------------------------------------------------
 
-#import <Foundation/Foundation.h>
+#import "TOSMBSessionTask.h"
 #import "TOSMBConstants.h"
 
 @class TOSMBSession;
@@ -74,10 +74,7 @@ totalBytesExpectedToReceive:(uint64_t)totalBytesToReceive;
 
 @end
 
-@interface TOSMBSessionDownloadTask : NSObject
-
-/** The parent session that is managing this download task. (Retained by this class) */
-@property (readonly, weak) TOSMBSession *session;
+@interface TOSMBSessionDownloadTask : TOSMBSessionTask
 
 /** The file path to the target file on the SMB network device. */
 @property (readonly) NSString *sourceFilePath;
@@ -90,29 +87,5 @@ totalBytesExpectedToReceive:(uint64_t)totalBytesToReceive;
 
 /** The total number of bytes we expect to download */
 @property (readonly) int64_t countOfBytesExpectedToReceive;
-
-/** Returns if download data from a suspended task exists */
-@property (readonly) BOOL canBeResumed;
-
-/** The state of the download task. */
-@property (readonly) TOSMBSessionDownloadTaskState state;
-
-/**
- Resumes an existing download, or starts a new one otherwise.
- 
- Downloads are resumed if there is already data for this file on disk,
- and the modification date of that file matches the one on the network device.
- */
-- (void)resume;
-
-/**
- Suspends a download and halts network activity.
- */
-- (void)suspend;
-
-/**
- Cancels a download, and deletes all related transient data on disk.
- */
-- (void)cancel;
 
 @end

--- a/TOSMBClient/TOSMBSessionDownloadTask.m
+++ b/TOSMBClient/TOSMBSessionDownloadTask.m
@@ -25,7 +25,6 @@
 
 #import "TOSMBSessionDownloadTaskPrivate.h"
 #import "TOSMBSessionPrivate.h"
-#import "TOSMBSessionFilePrivate.h"
 
 
 // -------------------------------------------------------------------------
@@ -46,9 +45,6 @@
 
 @property (nonatomic, copy) void (^progressHandler)(uint64_t totalBytesWritten, uint64_t totalBytesExpected);
 @property (nonatomic, copy) void (^successHandler)(NSString *filePath);
-
-/* Download methods */
-- (TOSMBSessionFile *)requestFileForItemAtPath:(NSString *)filePath inTree:(smb_tid)treeID;
 
 /* File Path Methods */
 - (NSString *)hashForFilePath;
@@ -263,19 +259,6 @@
 }
 
 #pragma mark - Downloading -
-- (TOSMBSessionFile *)requestFileForItemAtPath:(NSString *)filePath inTree:(smb_tid)treeID
-{
-    const char *fileCString = [filePath cStringUsingEncoding:NSUTF8StringEncoding];
-    smb_stat fileStat = smb_fstat(self.smbSession, treeID, fileCString);
-    if (!fileStat)
-        return nil;
-    
-    TOSMBSessionFile *file = [[TOSMBSessionFile alloc] initWithStat:fileStat session:nil parentDirectoryFilePath:filePath];
-    
-    smb_stat_destroy(fileStat);
-    
-    return file;
-}
 
 - (void)performTaskWithOperation:(__weak NSBlockOperation *)weakOperation
 {

--- a/TOSMBClient/TOSMBSessionDownloadTask.m
+++ b/TOSMBClient/TOSMBSessionDownloadTask.m
@@ -32,8 +32,6 @@
 
 @interface TOSMBSessionDownloadTask ()
 
-@property (nonatomic, assign, readwrite) TOSMBSessionDownloadTaskState state;
-
 @property (nonatomic, strong, readwrite) NSString *sourceFilePath;
 @property (nonatomic, strong, readwrite) NSString *destinationFilePath;
 @property (nonatomic, strong) NSString *tempFilePath;
@@ -185,26 +183,26 @@
 #pragma mark - Public Control Methods -
 - (void)resume
 {
-    if (self.state == TOSMBSessionDownloadTaskStateRunning)
+    if (self.state == TOSMBSessionTaskStateRunning)
         return;
     
     [self.session.taskQueue addOperation:self.taskOperation];
-    self.state = TOSMBSessionDownloadTaskStateRunning;
+    self.state = TOSMBSessionTaskStateRunning;
 }
 
 - (void)suspend
 {
-    if (self.state != TOSMBSessionDownloadTaskStateRunning)
+    if (self.state != TOSMBSessionTaskStateRunning)
         return;
     
     [self.taskOperation cancel];
-    self.state = TOSMBSessionDownloadTaskStateSuspended;
+    self.state = TOSMBSessionTaskStateSuspended;
     self.taskOperation = nil;
 }
 
 - (void)cancel
 {
-    if (self.state != TOSMBSessionDownloadTaskStateRunning)
+    if (self.state != TOSMBSessionTaskStateRunning)
         return;
     
     id deleteBlock = ^{
@@ -219,7 +217,7 @@
     [self.session.taskQueue addOperation:deleteOperation];
     
     [self.taskOperation cancel];
-    self.state = TOSMBSessionDownloadTaskStateCancelled;
+    self.state = TOSMBSessionTaskStateCancelled;
     
     self.taskOperation = nil;
 }
@@ -227,12 +225,12 @@
 #pragma mark - Private Control Methods -
 - (void)fail
 {
-    if (self.state != TOSMBSessionDownloadTaskStateRunning)
+    if (self.state != TOSMBSessionTaskStateRunning)
         return;
 
     [self cancel];
 
-    self.state = TOSMBSessionDownloadTaskStateFailed;
+    self.state = TOSMBSessionTaskStateFailed;
 }
 
 #pragma mark - Feedback Methods -
@@ -455,7 +453,7 @@
     free(buffer);
     [fileHandle closeFile];
     
-    if (weakOperation.isCancelled  || self.state != TOSMBSessionDownloadTaskStateRunning) {
+    if (weakOperation.isCancelled  || self.state != TOSMBSessionTaskStateRunning) {
         self.cleanupBlock(treeID, fileID);
         return;
     }
@@ -467,7 +465,7 @@
     NSString *finalDestinationPath = [self finalFilePathForDownloadedFile];
     [[NSFileManager defaultManager] moveItemAtPath:self.tempFilePath toPath:finalDestinationPath error:nil];
     
-    self.state = TOSMBSessionDownloadTaskStateCompleted;
+    self.state = TOSMBSessionTaskStateCompleted;
     
     //Alert the delegate that we finished, so they may perform any additional cleanup operations
     [self didSucceedWithFilePath:finalDestinationPath];

--- a/TOSMBClient/TOSMBSessionDownloadTask.m
+++ b/TOSMBClient/TOSMBSessionDownloadTask.m
@@ -25,7 +25,6 @@
 
 #import "TOSMBSessionDownloadTaskPrivate.h"
 #import "TOSMBSessionPrivate.h"
-#import "TOSMBSessionTaskPrivate.h"
 #import "TOSMBSessionFilePrivate.h"
 
 
@@ -52,7 +51,6 @@
 @property (nonatomic, copy) void (^failHandler)(NSError *error);
 
 /* Download methods */
-- (void)performDownloadWithOperation:(__weak NSBlockOperation *)weakOperation;
 - (TOSMBSessionFile *)requestFileForItemAtPath:(NSString *)filePath inTree:(smb_tid)treeID;
 
 /* File Path Methods */
@@ -307,7 +305,7 @@
     return file;
 }
 
-- (void)performDownloadWithOperation:(__weak NSBlockOperation *)weakOperation
+- (void)performTaskWithOperation:(__weak NSBlockOperation *)weakOperation
 {
     if (weakOperation.isCancelled)
         return;

--- a/TOSMBClient/TOSMBSessionDownloadTask.m
+++ b/TOSMBClient/TOSMBSessionDownloadTask.m
@@ -192,7 +192,7 @@
         return;
     
     [self setupDownloadOperation];
-    [self.session.downloadsQueue addOperation:self.smbBlockOperation];
+    [self.session.taskQueue addOperation:self.smbBlockOperation];
     self.state = TOSMBSessionDownloadTaskStateRunning;
 }
 
@@ -220,7 +220,7 @@
     if (self.smbBlockOperation) { // if the download operation doesn't exist, we can delete file even immediately
         [deleteOperation addDependency:self.smbBlockOperation];
     }
-    [self.session.downloadsQueue addOperation:deleteOperation];
+    [self.session.taskQueue addOperation:deleteOperation];
     
     [self.smbBlockOperation cancel];
     self.state = TOSMBSessionDownloadTaskStateCancelled;

--- a/TOSMBClient/TOSMBSessionDownloadTask.m
+++ b/TOSMBClient/TOSMBSessionDownloadTask.m
@@ -204,17 +204,6 @@
     self.taskOperation = nil;
 }
 
-#pragma mark - Private Control Methods -
-- (void)fail
-{
-    if (self.state != TOSMBSessionTaskStateRunning)
-        return;
-
-    [self cancel];
-
-    self.state = TOSMBSessionTaskStateFailed;
-}
-
 #pragma mark - Feedback Methods -
 - (BOOL)canBeResumed
 {

--- a/TOSMBClient/TOSMBSessionDownloadTask.m
+++ b/TOSMBClient/TOSMBSessionDownloadTask.m
@@ -42,8 +42,6 @@
 
 /** Feedback handlers */
 @property (nonatomic, weak) id<TOSMBSessionDownloadTaskDelegate> delegate;
-
-@property (nonatomic, copy) void (^progressHandler)(uint64_t totalBytesWritten, uint64_t totalBytesExpected);
 @property (nonatomic, copy) void (^successHandler)(NSString *filePath);
 
 /* File Path Methods */
@@ -92,7 +90,7 @@
         _sourceFilePath = filePath;
         _destinationFilePath = destinationPath.length ? destinationPath : [self documentsDirectory];
         
-        _progressHandler = progressHandler;
+        self.progressHandler = progressHandler;
         _successHandler = successHandler;
         self.failHandler = failHandler;
         

--- a/TOSMBClient/TOSMBSessionDownloadTask.m
+++ b/TOSMBClient/TOSMBSessionDownloadTask.m
@@ -181,24 +181,6 @@
 }
 
 #pragma mark - Public Control Methods -
-- (void)resume
-{
-    if (self.state == TOSMBSessionTaskStateRunning)
-        return;
-    
-    [self.session.taskQueue addOperation:self.taskOperation];
-    self.state = TOSMBSessionTaskStateRunning;
-}
-
-- (void)suspend
-{
-    if (self.state != TOSMBSessionTaskStateRunning)
-        return;
-    
-    [self.taskOperation cancel];
-    self.state = TOSMBSessionTaskStateSuspended;
-    self.taskOperation = nil;
-}
 
 - (void)cancel
 {

--- a/TOSMBClient/TOSMBSessionDownloadTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionDownloadTaskPrivate.h
@@ -10,9 +10,10 @@
 #define TOSMBSessionDownloadTaskPrivate_h
 
 #import "TOSMBSessionDownloadTask.h"
+#import "TOSMBSessionTaskPrivate.h"
 #import "TOSMBSession.h"
 
-@interface TOSMBSessionDownloadTask ()
+@interface TOSMBSessionDownloadTask () <TOSMBSessionTaskSubclass>
 
 - (instancetype)initWithSession:(TOSMBSession *)session
                        filePath:(NSString *)filePath

--- a/TOSMBClient/TOSMBSessionDownloadTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionDownloadTaskPrivate.h
@@ -1,10 +1,24 @@
 //
-//  TOSMBSessionDownloadTaskPrivate.h
-//  TOSMBClient
+// TOSMBSessionDownloadTaskPrivate.h
+// Copyright 2015-2016 Timothy Oliver
 //
-//  Created by Nicholas Spencer on 11/13/16.
-//  Copyright © 2016 TimOliver. All rights reserved.
+// This file is dual-licensed under both the MIT License, and the LGPL v2.1 License.
 //
+// -------------------------------------------------------------------------------
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// -------------------------------------------------------------------------------
 
 #ifndef TOSMBSessionDownloadTaskPrivate_h
 #define TOSMBSessionDownloadTaskPrivate_h
@@ -13,7 +27,7 @@
 #import "TOSMBSessionTaskPrivate.h"
 #import "TOSMBSession.h"
 
-@interface TOSMBSessionDownloadTask () <TOSMBSessionTaskSubclass>
+@interface TOSMBSessionDownloadTask () <TOSMBSessionConcreteTask>
 
 - (instancetype)initWithSession:(TOSMBSession *)session
                        filePath:(NSString *)filePath

--- a/TOSMBClient/TOSMBSessionDownloadTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionDownloadTaskPrivate.h
@@ -1,0 +1,31 @@
+//
+//  TOSMBSessionDownloadTaskPrivate.h
+//  TOSMBClient
+//
+//  Created by Nicholas Spencer on 11/13/16.
+//  Copyright © 2016 TimOliver. All rights reserved.
+//
+
+#ifndef TOSMBSessionDownloadTaskPrivate_h
+#define TOSMBSessionDownloadTaskPrivate_h
+
+#import "TOSMBSessionDownloadTask.h"
+#import "TOSMBSession.h"
+
+@interface TOSMBSessionDownloadTask ()
+
+- (instancetype)initWithSession:(TOSMBSession *)session
+                       filePath:(NSString *)filePath
+                destinationPath:(NSString *)destinationPath
+                       delegate:(id<TOSMBSessionDownloadTaskDelegate>)delegate;
+
+- (instancetype)initWithSession:(TOSMBSession *)session
+                       filePath:(NSString *)filePath
+                destinationPath:(NSString *)destinationPath
+                progressHandler:(id)progressHandler
+                 successHandler:(id)successHandler
+                    failHandler:(id)failHandler;
+
+@end
+
+#endif /* TOSMBSessionDownloadTaskPrivate_h */

--- a/TOSMBClient/TOSMBSessionPrivate.h
+++ b/TOSMBClient/TOSMBSessionPrivate.h
@@ -1,5 +1,5 @@
 //
-// TOSMBClient.h
+// TOSMBSessionPrivate.h
 // Copyright 2015-2016 Timothy Oliver
 //
 // This file is dual-licensed under both the MIT License, and the LGPL v2.1 License.
@@ -20,28 +20,24 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // -------------------------------------------------------------------------------
 
-//! Project version number for TOSMBClient.
-FOUNDATION_EXPORT double TOSMBClientVersionNumber;
-
-//! Project version string for TOSMBClient.
-FOUNDATION_EXPORT const unsigned char TOSMBClientVersionString[];
-
-#import "TOSMBConstants.h"
+#ifndef TOSMBSessionPrivate_h
+#define TOSMBSessionPrivate_h
 
 #import "TOSMBSession.h"
-#import "TOSMBSessionFile.h"
-#import "TOSMBSessionTask.h"
-#import "TOSMBSessionDownloadTask.h"
-#import "TOSMBSessionUploadTask.h"
+#import "smb_session.h"
 
-#import "TONetBIOSNameService.h"
-#import "TONetBIOSNameServiceEntry.h"
+@interface TOSMBSession ()
 
-#import "TOSMBConstants.h"
+@property (readonly) NSOperationQueue *downloadsQueue;
 
-#import "TOSMBSession.h"
-#import "TOSMBSessionFile.h"
-#import "TOSMBSessionDownloadTask.h"
+@property (readonly) dispatch_queue_t serialQueue;
 
-#import "TONetBIOSNameService.h"
-#import "TONetBIOSNameServiceEntry.h"
+- (NSError *)attemptConnectionWithSessionPointer:(smb_session *)session;
+- (NSString *)shareNameFromPath:(NSString *)path;
+- (NSString *)filePathExcludingSharePathFromPath:(NSString *)path;
+- (void)resumeDownloadTask:(TOSMBSessionDownloadTask *)task;
+
+@end
+
+
+#endif /* TOSMBSessionPrivate_h */

--- a/TOSMBClient/TOSMBSessionPrivate.h
+++ b/TOSMBClient/TOSMBSessionPrivate.h
@@ -31,7 +31,6 @@
 - (NSError *)attemptConnectionWithSessionPointer:(smb_session *)session;
 - (NSString *)shareNameFromPath:(NSString *)path;
 - (NSString *)filePathExcludingSharePathFromPath:(NSString *)path;
-//- (void)resumeDownloadTask:(TOSMBSessionDownloadTask *)task;
 
 @end
 

--- a/TOSMBClient/TOSMBSessionPrivate.h
+++ b/TOSMBClient/TOSMBSessionPrivate.h
@@ -28,16 +28,11 @@
 
 @interface TOSMBSession ()
 
-@property (readonly) NSOperationQueue *downloadsQueue;
-
-@property (readonly) dispatch_queue_t serialQueue;
-
 - (NSError *)attemptConnectionWithSessionPointer:(smb_session *)session;
 - (NSString *)shareNameFromPath:(NSString *)path;
 - (NSString *)filePathExcludingSharePathFromPath:(NSString *)path;
-- (void)resumeDownloadTask:(TOSMBSessionDownloadTask *)task;
+//- (void)resumeDownloadTask:(TOSMBSessionDownloadTask *)task;
 
 @end
-
 
 #endif /* TOSMBSessionPrivate_h */

--- a/TOSMBClient/TOSMBSessionTask.h
+++ b/TOSMBClient/TOSMBSessionTask.h
@@ -24,7 +24,20 @@
 
 #import "TOSMBConstants.h"
 
+@class TOSMBSessionTask;
 @class TOSMBSession;
+
+@protocol TOSMBSessionTaskDelegate <NSObject>
+@optional
+/**
+ Delegate event that is called when the file did not successfully complete.
+ 
+ @param downloadTask The download task object calling this delegate method.
+ @param error The error describing why the task failed.
+ */
+- (void)task:(TOSMBSessionTask *)task didCompleteWithError:(NSError *)error;
+
+@end
 
 @interface TOSMBSessionTask : NSObject
 

--- a/TOSMBClient/TOSMBSessionTask.h
+++ b/TOSMBClient/TOSMBSessionTask.h
@@ -1,5 +1,5 @@
 //
-// TOSMBClient.h
+// TOSMBSessionTask.h
 // Copyright 2015-2016 Timothy Oliver
 //
 // This file is dual-licensed under both the MIT License, and the LGPL v2.1 License.
@@ -20,28 +20,39 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // -------------------------------------------------------------------------------
 
-//! Project version number for TOSMBClient.
-FOUNDATION_EXPORT double TOSMBClientVersionNumber;
-
-//! Project version string for TOSMBClient.
-FOUNDATION_EXPORT const unsigned char TOSMBClientVersionString[];
+#import <Foundation/Foundation.h>
 
 #import "TOSMBConstants.h"
 
-#import "TOSMBSession.h"
-#import "TOSMBSessionFile.h"
-#import "TOSMBSessionTask.h"
-#import "TOSMBSessionDownloadTask.h"
-#import "TOSMBSessionUploadTask.h"
+@class TOSMBSession;
 
-#import "TONetBIOSNameService.h"
-#import "TONetBIOSNameServiceEntry.h"
+@interface TOSMBSessionTask : NSObject
 
-#import "TOSMBConstants.h"
+/** The parent session that is managing this download task. (Retained by this class) */
+@property (readonly, weak) TOSMBSession *session;
 
-#import "TOSMBSession.h"
-#import "TOSMBSessionFile.h"
-#import "TOSMBSessionDownloadTask.h"
+/** Returns if download data from a suspended task exists */
+@property (readonly) BOOL canBeResumed;
 
-#import "TONetBIOSNameService.h"
-#import "TONetBIOSNameServiceEntry.h"
+/** The state of the task. */
+@property (readonly) TOSMBSessionTaskState state;
+
+/**
+ Resumes an existing task, or starts a new one otherwise.
+ 
+ Downloads are resumed if there is already data for this file on disk,
+ and the modification date of that file matches the one on the network device.
+ */
+- (void)resume;
+
+/**
+ Suspends a task and halts network activity.
+ */
+- (void)suspend;
+
+/**
+ Cancels a task, and deletes all related transient data on disk.
+ */
+- (void)cancel;
+
+@end

--- a/TOSMBClient/TOSMBSessionTask.m
+++ b/TOSMBClient/TOSMBSessionTask.m
@@ -1,5 +1,5 @@
 //
-// TOSMBClient.h
+// TOSMBSessionTask.h
 // Copyright 2015-2016 Timothy Oliver
 //
 // This file is dual-licensed under both the MIT License, and the LGPL v2.1 License.
@@ -20,28 +20,21 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // -------------------------------------------------------------------------------
 
-//! Project version number for TOSMBClient.
-FOUNDATION_EXPORT double TOSMBClientVersionNumber;
-
-//! Project version string for TOSMBClient.
-FOUNDATION_EXPORT const unsigned char TOSMBClientVersionString[];
-
-#import "TOSMBConstants.h"
-
-#import "TOSMBSession.h"
-#import "TOSMBSessionFile.h"
 #import "TOSMBSessionTask.h"
-#import "TOSMBSessionDownloadTask.h"
-#import "TOSMBSessionUploadTask.h"
+#import "TOSMBSessionTaskPrivate.h"
 
-#import "TONetBIOSNameService.h"
-#import "TONetBIOSNameServiceEntry.h"
+@implementation TOSMBSessionTask
 
-#import "TOSMBConstants.h"
+- (void)resume {
+    return;
+}
 
-#import "TOSMBSession.h"
-#import "TOSMBSessionFile.h"
-#import "TOSMBSessionDownloadTask.h"
+- (void)suspend {
+    return;
+}
 
-#import "TONetBIOSNameService.h"
-#import "TONetBIOSNameServiceEntry.h"
+- (void)cancel {
+    return;
+}
+
+@end

--- a/TOSMBClient/TOSMBSessionTask.m
+++ b/TOSMBClient/TOSMBSessionTask.m
@@ -126,4 +126,16 @@
     self.state = TOSMBSessionTaskStateFailed;
 }
 
+#pragma mark - Feedback Methods -
+
+- (void)didFailWithError:(NSError *)error
+{
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        if (self.delegate && [self.delegate respondsToSelector:@selector(task:didCompleteWithError:)])
+            [self.delegate task:self didCompleteWithError:error];
+        if (self.failHandler)
+            self.failHandler(error);
+    });
+}
+
 @end

--- a/TOSMBClient/TOSMBSessionTask.m
+++ b/TOSMBClient/TOSMBSessionTask.m
@@ -78,6 +78,20 @@
 
 #pragma mark - Task Methods
 
+- (TOSMBSessionFile *)requestFileForItemAtPath:(NSString *)filePath inTree:(smb_tid)treeID
+{
+    const char *fileCString = [filePath cStringUsingEncoding:NSUTF8StringEncoding];
+    smb_stat fileStat = smb_fstat(self.smbSession, treeID, fileCString);
+    if (!fileStat)
+        return nil;
+    
+    TOSMBSessionFile *file = [[TOSMBSessionFile alloc] initWithStat:fileStat session:nil parentDirectoryFilePath:filePath];
+    
+    smb_stat_destroy(fileStat);
+    
+    return file;
+}
+
 - (void)performTaskWithOperation:(__weak NSBlockOperation *)operation {
     return;
 }

--- a/TOSMBClient/TOSMBSessionTask.m
+++ b/TOSMBClient/TOSMBSessionTask.m
@@ -82,7 +82,8 @@
     return;
 }
 
-#pragma mark - Public Control Methods -
+#pragma mark - Public Control Methods
+
 - (void)resume
 {
     if (self.state == TOSMBSessionTaskStateRunning)
@@ -111,6 +112,18 @@
     self.state = TOSMBSessionTaskStateCancelled;
     
     self.taskOperation = nil;
+}
+
+#pragma mark - Private Control Methods
+
+- (void)fail
+{
+    if (self.state != TOSMBSessionTaskStateRunning)
+        return;
+    
+    [self cancel];
+    
+    self.state = TOSMBSessionTaskStateFailed;
 }
 
 @end

--- a/TOSMBClient/TOSMBSessionTask.m
+++ b/TOSMBClient/TOSMBSessionTask.m
@@ -78,7 +78,7 @@
 
 #pragma mark - Task Methods
 
-- (void)performTaskWithOperation:(NSBlockOperation *)operation {
+- (void)performTaskWithOperation:(__weak NSBlockOperation *)operation {
     return;
 }
 

--- a/TOSMBClient/TOSMBSessionTask.m
+++ b/TOSMBClient/TOSMBSessionTask.m
@@ -82,16 +82,35 @@
     return;
 }
 
-- (void)resume {
-    return;
+#pragma mark - Public Control Methods -
+- (void)resume
+{
+    if (self.state == TOSMBSessionTaskStateRunning)
+        return;
+    
+    [self.session.taskQueue addOperation:self.taskOperation];
+    self.state = TOSMBSessionTaskStateRunning;
 }
 
-- (void)suspend {
-    return;
+- (void)suspend
+{
+    if (self.state != TOSMBSessionTaskStateRunning)
+        return;
+    
+    [self.taskOperation cancel];
+    self.state = TOSMBSessionTaskStateSuspended;
+    self.taskOperation = nil;
 }
 
-- (void)cancel {
-    return;
+- (void)cancel
+{
+    if (self.state != TOSMBSessionTaskStateRunning)
+        return;
+    
+    [self.taskOperation cancel];
+    self.state = TOSMBSessionTaskStateCancelled;
+    
+    self.taskOperation = nil;
 }
 
 @end

--- a/TOSMBClient/TOSMBSessionTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionTaskPrivate.h
@@ -32,18 +32,25 @@
 #import "smb_session.h"
 #import "smb_share.h"
 
-@interface TOSMBSessionTask ()
+NS_ASSUME_NONNULL_BEGIN
 
-@property (nonatomic, weak, readwrite) TOSMBSession *session;
-@property (nonatomic, assign, readwrite) TOSMBSessionTaskState state;
+@interface TOSMBSessionTask () {
+    @protected
+    NSBlockOperation *_taskOperation;
+}
+
+@property (nonatomic, weak) TOSMBSession *session;
+@property (nonatomic, assign) TOSMBSessionTaskState state;
 @property (nonatomic, assign) UIBackgroundTaskIdentifier backgroundTaskIdentifier;
 
-@property (assign) smb_session *smbSession;
-@property (nonatomic, strong) NSBlockOperation *smbBlockOperation;
+@property (nonatomic, assign, nullable) smb_session *smbSession;
+@property (nonatomic, strong, null_resettable) NSBlockOperation *taskOperation;
 @property (nonatomic, readonly) void (^cleanupBlock)(smb_tid treeID, smb_fd fileID);
 
 - (instancetype)initWithSession:(TOSMBSession *)session;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 #endif /* TOSMBSessionTaskPrivate_h */

--- a/TOSMBClient/TOSMBSessionTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionTaskPrivate.h
@@ -50,9 +50,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, null_resettable) NSBlockOperation *taskOperation;
 @property (nonatomic, readonly) void (^cleanupBlock)(smb_tid treeID, smb_fd fileID);
 
+/** Feedback handlers */
+@property (nonatomic, weak) id<TOSMBSessionTaskDelegate> delegate;
+@property (nonatomic, copy) void (^failHandler)(NSError *error);
+
 - (instancetype)initWithSession:(TOSMBSession *)session;
 
 - (void)fail;
+
+- (void)didFailWithError:(NSError *)error;
 
 @end
 

--- a/TOSMBClient/TOSMBSessionTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionTaskPrivate.h
@@ -35,7 +35,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol TOSMBSessionTaskSubclass <NSObject>
+@protocol TOSMBSessionConcreteTask <NSObject>
 
 - (void)performTaskWithOperation:(__weak NSBlockOperation *)weakOperation;
 

--- a/TOSMBClient/TOSMBSessionTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionTaskPrivate.h
@@ -27,6 +27,7 @@
 
 #import "TOSMBSessionTask.h"
 #import "TOSMBSession.h"
+#import "TOSMBSessionFilePrivate.h"
 #import "smb_defs.h"
 #import "smb_file.h"
 #import "smb_session.h"
@@ -56,8 +57,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithSession:(TOSMBSession *)session;
 
-- (void)fail;
+- (TOSMBSessionFile *)requestFileForItemAtPath:(NSString *)filePath inTree:(smb_tid)treeID;
 
+- (void)fail;
 - (void)didFailWithError:(NSError *)error;
 
 @end

--- a/TOSMBClient/TOSMBSessionTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionTaskPrivate.h
@@ -1,5 +1,5 @@
 //
-// TOSMBClient.h
+// TOSMBSessionTaskPrivate.h
 // Copyright 2015-2016 Timothy Oliver
 //
 // This file is dual-licensed under both the MIT License, and the LGPL v2.1 License.
@@ -20,28 +20,24 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // -------------------------------------------------------------------------------
 
-//! Project version number for TOSMBClient.
-FOUNDATION_EXPORT double TOSMBClientVersionNumber;
+#ifndef TOSMBSessionTaskPrivate_h
+#define TOSMBSessionTaskPrivate_h
 
-//! Project version string for TOSMBClient.
-FOUNDATION_EXPORT const unsigned char TOSMBClientVersionString[];
+@import UIKit;
 
-#import "TOSMBConstants.h"
-
-#import "TOSMBSession.h"
-#import "TOSMBSessionFile.h"
 #import "TOSMBSessionTask.h"
-#import "TOSMBSessionDownloadTask.h"
-#import "TOSMBSessionUploadTask.h"
-
-#import "TONetBIOSNameService.h"
-#import "TONetBIOSNameServiceEntry.h"
-
-#import "TOSMBConstants.h"
-
 #import "TOSMBSession.h"
-#import "TOSMBSessionFile.h"
-#import "TOSMBSessionDownloadTask.h"
+#import "smb_session.h"
 
-#import "TONetBIOSNameService.h"
-#import "TONetBIOSNameServiceEntry.h"
+@interface TOSMBSessionTask ()
+
+@property (nonatomic, weak, readwrite) TOSMBSession *session;
+@property (nonatomic, assign, readwrite) TOSMBSessionTaskState state;
+@property (nonatomic, assign) UIBackgroundTaskIdentifier backgroundTaskIdentifier;
+
+@property (assign) smb_session *smbSession;
+@property (nonatomic, strong) NSBlockOperation *smbBlockOperation;
+
+@end
+
+#endif /* TOSMBSessionTaskPrivate_h */

--- a/TOSMBClient/TOSMBSessionTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionTaskPrivate.h
@@ -53,6 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Feedback handlers */
 @property (nonatomic, weak) id<TOSMBSessionTaskDelegate> delegate;
+@property (nonatomic, copy) void (^progressHandler)(uint64_t totalBytesWritten, uint64_t totalBytesExpected);
 @property (nonatomic, copy) void (^failHandler)(NSError *error);
 
 - (instancetype)initWithSession:(TOSMBSession *)session;

--- a/TOSMBClient/TOSMBSessionTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionTaskPrivate.h
@@ -27,7 +27,10 @@
 
 #import "TOSMBSessionTask.h"
 #import "TOSMBSession.h"
+#import "smb_defs.h"
+#import "smb_file.h"
 #import "smb_session.h"
+#import "smb_share.h"
 
 @interface TOSMBSessionTask ()
 
@@ -37,6 +40,9 @@
 
 @property (assign) smb_session *smbSession;
 @property (nonatomic, strong) NSBlockOperation *smbBlockOperation;
+@property (nonatomic, readonly) void (^cleanupBlock)(smb_tid treeID, smb_fd fileID);
+
+- (instancetype)initWithSession:(TOSMBSession *)session;
 
 @end
 

--- a/TOSMBClient/TOSMBSessionTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionTaskPrivate.h
@@ -52,6 +52,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithSession:(TOSMBSession *)session;
 
+- (void)fail;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/TOSMBClient/TOSMBSessionTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionTaskPrivate.h
@@ -34,6 +34,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@protocol TOSMBSessionTaskSubclass <NSObject>
+
+- (void)performTaskWithOperation:(__weak NSBlockOperation *)weakOperation;
+
+@end
+
 @interface TOSMBSessionTask ()
 
 @property (nonatomic, weak) TOSMBSession *session;

--- a/TOSMBClient/TOSMBSessionTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionTaskPrivate.h
@@ -34,10 +34,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface TOSMBSessionTask () {
-    @protected
-    NSBlockOperation *_taskOperation;
-}
+@interface TOSMBSessionTask ()
 
 @property (nonatomic, weak) TOSMBSession *session;
 @property (nonatomic, assign) TOSMBSessionTaskState state;

--- a/TOSMBClient/TOSMBSessionUploadTask.h
+++ b/TOSMBClient/TOSMBSessionUploadTask.h
@@ -37,6 +37,4 @@ totalBytesExpectedToSend:(uint64_t)totalBytesExpectedToSend;
 
 @property (nonatomic, weak) id <TOSMBSessionUploadTaskDelegate> delegate;
 
-//- (instancetype)init;
-
 @end

--- a/TOSMBClient/TOSMBSessionUploadTask.h
+++ b/TOSMBClient/TOSMBSessionUploadTask.h
@@ -1,5 +1,5 @@
 //
-// TOSMBClient.h
+// TOSMBSessionUploadTask.h
 // Copyright 2015-2016 Timothy Oliver
 //
 // This file is dual-licensed under both the MIT License, and the LGPL v2.1 License.
@@ -20,28 +20,23 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // -------------------------------------------------------------------------------
 
-//! Project version number for TOSMBClient.
-FOUNDATION_EXPORT double TOSMBClientVersionNumber;
-
-//! Project version string for TOSMBClient.
-FOUNDATION_EXPORT const unsigned char TOSMBClientVersionString[];
-
-#import "TOSMBConstants.h"
-
-#import "TOSMBSession.h"
-#import "TOSMBSessionFile.h"
 #import "TOSMBSessionTask.h"
-#import "TOSMBSessionDownloadTask.h"
-#import "TOSMBSessionUploadTask.h"
 
-#import "TONetBIOSNameService.h"
-#import "TONetBIOSNameServiceEntry.h"
+@class TOSMBSessionUploadTask;
 
-#import "TOSMBConstants.h"
+@protocol TOSMBSessionUploadTaskDelegate <NSObject>
 
-#import "TOSMBSession.h"
-#import "TOSMBSessionFile.h"
-#import "TOSMBSessionDownloadTask.h"
+- (void)uploadTask:(TOSMBSessionUploadTask *)task
+      didSendBytes:(uint64_t)bytesSent
+    totalBytesSent:(uint64_t)totalBytesSent
+totalBytesExpectedToSend:(uint64_t)totalBytesExpectedToSend;
 
-#import "TONetBIOSNameService.h"
-#import "TONetBIOSNameServiceEntry.h"
+@end
+
+@interface TOSMBSessionUploadTask : TOSMBSessionTask
+
+@property (nonatomic, weak) id <TOSMBSessionUploadTaskDelegate> delegate;
+
+//- (instancetype)init;
+
+@end

--- a/TOSMBClient/TOSMBSessionUploadTask.h
+++ b/TOSMBClient/TOSMBSessionUploadTask.h
@@ -27,6 +27,8 @@
 @protocol TOSMBSessionUploadTaskDelegate <TOSMBSessionTaskDelegate>
 @optional
 
+- (void)uploadTaskDidFinishUploading:(TOSMBSessionUploadTask *)task;
+
 - (void)uploadTask:(TOSMBSessionUploadTask *)task
       didSendBytes:(uint64_t)bytesSent
     totalBytesSent:(uint64_t)totalBytesSent

--- a/TOSMBClient/TOSMBSessionUploadTask.h
+++ b/TOSMBClient/TOSMBSessionUploadTask.h
@@ -24,7 +24,8 @@
 
 @class TOSMBSessionUploadTask;
 
-@protocol TOSMBSessionUploadTaskDelegate <NSObject>
+@protocol TOSMBSessionUploadTaskDelegate <TOSMBSessionTaskDelegate>
+@optional
 
 - (void)uploadTask:(TOSMBSessionUploadTask *)task
       didSendBytes:(uint64_t)bytesSent
@@ -34,7 +35,5 @@ totalBytesExpectedToSend:(uint64_t)totalBytesExpectedToSend;
 @end
 
 @interface TOSMBSessionUploadTask : TOSMBSessionTask
-
-@property (nonatomic, weak) id <TOSMBSessionUploadTaskDelegate> delegate;
 
 @end

--- a/TOSMBClient/TOSMBSessionUploadTask.m
+++ b/TOSMBClient/TOSMBSessionUploadTask.m
@@ -205,6 +205,8 @@
         [self didSendBytes:bytesWritten bytesSent:totalBytesWritten];
     } while (totalBytesWritten < bufferSize);
     
+    free(buffer);
+    
     [self didFinish];
 }
 

--- a/TOSMBClient/TOSMBSessionUploadTask.m
+++ b/TOSMBClient/TOSMBSessionUploadTask.m
@@ -21,7 +21,33 @@
 // -------------------------------------------------------------------------------
 
 #import "TOSMBSessionUploadTaskPrivate.h"
+#import "TOSMBSessionTaskPrivate.h"
+
+@interface TOSMBSessionUploadTask ()
+
+@property (nonatomic, copy) NSString *path;
+@property (nonatomic, strong) NSData *data;
+
+@property (nonatomic, copy) void (^successHandler)();
+@property (nonatomic, copy) void (^failHandler)(NSError *error);
+
+@end
 
 @implementation TOSMBSessionUploadTask
+
+- (instancetype)initWithSession:(TOSMBSession *)session
+                           path:(NSString *)path
+                           data:(NSData *)data
+                 successHandler:(id)successHandler
+                    failHandler:(id)failHandler {
+    if ((self = [super initWithSession:session])) {
+        self.path = path;
+        self.data = data;
+        self.successHandler = successHandler;
+        self.failHandler = failHandler;
+    }
+    
+    return self;
+}
 
 @end

--- a/TOSMBClient/TOSMBSessionUploadTask.m
+++ b/TOSMBClient/TOSMBSessionUploadTask.m
@@ -21,11 +21,14 @@
 // -------------------------------------------------------------------------------
 
 #import "TOSMBSessionUploadTaskPrivate.h"
+#import "TOSMBSessionPrivate.h"
 
 @interface TOSMBSessionUploadTask ()
 
 @property (nonatomic, copy) NSString *path;
-@property (nonatomic, strong) NSData *data;
+@property (nonatomic, copy) NSData *data;
+
+@property (nonatomic, strong) TOSMBSessionFile *file;
 
 @property (nonatomic, weak) id <TOSMBSessionUploadTaskDelegate> delegate;
 @property (nonatomic, copy) void (^successHandler)();
@@ -72,7 +75,107 @@
 }
 
 - (void)performTaskWithOperation:(NSBlockOperation * _Nonnull __weak)weakOperation {
+    if (weakOperation.isCancelled)
+        return;
     
+    smb_tid treeID = 0;
+    smb_fd fileID = 0;
+    
+    //---------------------------------------------------------------------------------------
+    //Connect to SMB device
+    
+    self.smbSession = smb_session_new();
+    
+    //First, check to make sure the server is there, and to acquire its attributes
+    __block NSError *error = nil;
+    dispatch_sync(self.session.serialQueue, ^{
+        error = [self.session attemptConnectionWithSessionPointer:self.smbSession];
+    });
+    if (error) {
+        [self didFailWithError:error];
+        self.cleanupBlock(treeID, fileID);
+        return;
+    }
+    
+    if (weakOperation.isCancelled) {
+        self.cleanupBlock(treeID, fileID);
+        return;
+    }
+    
+    //---------------------------------------------------------------------------------------
+    //Connect to share
+    
+    //Next attach to the share we'll be using
+    NSString *shareName = [self.session shareNameFromPath:self.path];
+    const char *shareCString = [shareName cStringUsingEncoding:NSUTF8StringEncoding];
+    smb_tree_connect(self.smbSession, shareCString, &treeID);
+    if (!treeID) {
+        [self didFailWithError:errorForErrorCode(TOSMBSessionErrorCodeShareConnectionFailed)];
+        self.cleanupBlock(treeID, fileID);
+        return;
+    }
+    
+    if (weakOperation.isCancelled) {
+        self.cleanupBlock(treeID, fileID);
+        return;
+    }
+    
+    //---------------------------------------------------------------------------------------
+    //Find the target file
+    
+    NSString *formattedPath = [self.session filePathExcludingSharePathFromPath:self.path];
+    formattedPath = [NSString stringWithFormat:@"\\%@",formattedPath];
+    formattedPath = [formattedPath stringByReplacingOccurrencesOfString:@"/" withString:@"\\\\"];
+    
+    //Get the file info we'll be working off
+    self.file = [self requestFileForItemAtPath:formattedPath inTree:treeID];
+    if (self.file == nil) {
+        [self didFailWithError:errorForErrorCode(TOSMBSessionErrorCodeFileNotFound)];
+        self.cleanupBlock(treeID, fileID);
+        return;
+    }
+    
+    if (weakOperation.isCancelled) {
+        self.cleanupBlock(treeID, fileID);
+        return;
+    }
+    
+    if (self.file.directory) {
+        [self didFailWithError:errorForErrorCode(TOSMBSessionErrorCodeDirectoryDownloaded)];
+        self.cleanupBlock(treeID, fileID);
+        return;
+    }
+    
+    //---------------------------------------------------------------------------------------
+    //Open the file handle
+    
+    smb_fopen(self.smbSession, treeID, [formattedPath cStringUsingEncoding:NSUTF8StringEncoding], SMB_MOD_RW, &fileID);
+    if (!fileID) {
+        [self didFailWithError:errorForErrorCode(TOSMBSessionErrorCodeFileNotFound)];
+        self.cleanupBlock(treeID, fileID);
+        return;
+    }
+    
+    if (weakOperation.isCancelled) {
+        self.cleanupBlock(treeID, fileID);
+        return;
+    }
+    
+    NSUInteger bufferSize = self.data.length;
+    void *buffer = malloc(bufferSize);
+    [self.data getBytes:buffer length:bufferSize];
+    size_t uploadBufferLimit = MIN(bufferSize, 65471);
+    
+    ssize_t bytesWritten = 0;
+    
+    do {
+        bytesWritten = smb_fwrite(self.smbSession, fileID, buffer, uploadBufferLimit);
+        if (bytesWritten < 0) {
+            [self fail];
+            [self didFailWithError:errorForErrorCode(TOSMBSessionErrorCodeFileDownloadFailed)];
+            break;
+        }
+    } while (bytesWritten > 0);
 }
 
 

--- a/TOSMBClient/TOSMBSessionUploadTask.m
+++ b/TOSMBClient/TOSMBSessionUploadTask.m
@@ -21,7 +21,6 @@
 // -------------------------------------------------------------------------------
 
 #import "TOSMBSessionUploadTaskPrivate.h"
-#import "TOSMBSessionTaskPrivate.h"
 
 @interface TOSMBSessionUploadTask ()
 
@@ -51,5 +50,10 @@
     
     return self;
 }
+
+- (void)performTaskWithOperation:(NSBlockOperation * _Nonnull __weak)weakOperation {
+    
+}
+
 
 @end

--- a/TOSMBClient/TOSMBSessionUploadTask.m
+++ b/TOSMBClient/TOSMBSessionUploadTask.m
@@ -27,23 +27,43 @@
 @property (nonatomic, copy) NSString *path;
 @property (nonatomic, strong) NSData *data;
 
+@property (nonatomic, weak) id <TOSMBSessionUploadTaskDelegate> delegate;
 @property (nonatomic, copy) void (^successHandler)();
-@property (nonatomic, copy) void (^failHandler)(NSError *error);
 
 @end
 
 @implementation TOSMBSessionUploadTask
 
-@dynamic taskOperation;
+@dynamic delegate;
+
+- (instancetype)initWithSession:(TOSMBSession *)session
+                           path:(NSString *)path
+                           data:(NSData *)data {
+    if ((self = [super initWithSession:session])) {
+        self.path = path;
+        self.data = data;
+    }
+    
+    return self;
+}
+
+- (instancetype)initWithSession:(TOSMBSession *)session
+                           path:(NSString *)path
+                           data:(NSData *)data
+                       delegate:(id<TOSMBSessionUploadTaskDelegate>)delegate {
+    if ((self = [self initWithSession:session path:path data:data])) {
+        self.delegate = delegate;
+    }
+    
+    return self;
+}
 
 - (instancetype)initWithSession:(TOSMBSession *)session
                            path:(NSString *)path
                            data:(NSData *)data
                  successHandler:(id)successHandler
                     failHandler:(id)failHandler {
-    if ((self = [super initWithSession:session])) {
-        self.path = path;
-        self.data = data;
+    if ((self = [self initWithSession:session path:path data:data])) {
         self.successHandler = successHandler;
         self.failHandler = failHandler;
     }

--- a/TOSMBClient/TOSMBSessionUploadTask.m
+++ b/TOSMBClient/TOSMBSessionUploadTask.m
@@ -35,6 +35,8 @@
 
 @implementation TOSMBSessionUploadTask
 
+@dynamic taskOperation;
+
 - (instancetype)initWithSession:(TOSMBSession *)session
                            path:(NSString *)path
                            data:(NSData *)data

--- a/TOSMBClient/TOSMBSessionUploadTask.m
+++ b/TOSMBClient/TOSMBSessionUploadTask.m
@@ -1,5 +1,5 @@
 //
-// TOSMBClient.h
+// TOSMBSessionUploadTake.m
 // Copyright 2015-2016 Timothy Oliver
 //
 // This file is dual-licensed under both the MIT License, and the LGPL v2.1 License.
@@ -20,28 +20,8 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // -------------------------------------------------------------------------------
 
-//! Project version number for TOSMBClient.
-FOUNDATION_EXPORT double TOSMBClientVersionNumber;
+#import "TOSMBSessionUploadTaskPrivate.h"
 
-//! Project version string for TOSMBClient.
-FOUNDATION_EXPORT const unsigned char TOSMBClientVersionString[];
+@implementation TOSMBSessionUploadTask
 
-#import "TOSMBConstants.h"
-
-#import "TOSMBSession.h"
-#import "TOSMBSessionFile.h"
-#import "TOSMBSessionTask.h"
-#import "TOSMBSessionDownloadTask.h"
-#import "TOSMBSessionUploadTask.h"
-
-#import "TONetBIOSNameService.h"
-#import "TONetBIOSNameServiceEntry.h"
-
-#import "TOSMBConstants.h"
-
-#import "TOSMBSession.h"
-#import "TOSMBSessionFile.h"
-#import "TOSMBSessionDownloadTask.h"
-
-#import "TONetBIOSNameService.h"
-#import "TONetBIOSNameServiceEntry.h"
+@end

--- a/TOSMBClient/TOSMBSessionUploadTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionUploadTaskPrivate.h
@@ -27,7 +27,7 @@
 #import "TOSMBSessionUploadTask.h"
 #import "TOSMBSessionTaskPrivate.h"
 
-@interface TOSMBSessionUploadTask () <TOSMBSessionTaskSubclass>
+@interface TOSMBSessionUploadTask () <TOSMBSessionConcreteTask>
 
 - (instancetype)initWithSession:(TOSMBSession *)session
                            path:(NSString *)path

--- a/TOSMBClient/TOSMBSessionUploadTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionUploadTaskPrivate.h
@@ -28,6 +28,12 @@
 
 @interface TOSMBSessionUploadTask ()
 
+- (instancetype)initWithSession:(TOSMBSession *)session
+                           path:(NSString *)path
+                           data:(NSData *)data
+                 successHandler:(id)successHandler
+                    failHandler:(id)failHandler;
+
 @end
 
 #endif /* TOSMBSessionUploadTaskPrivate_h */

--- a/TOSMBClient/TOSMBSessionUploadTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionUploadTaskPrivate.h
@@ -37,6 +37,7 @@
 - (instancetype)initWithSession:(TOSMBSession *)session
                            path:(NSString *)path
                            data:(NSData *)data
+                progressHandler:(id)progressHandler
                  successHandler:(id)successHandler
                     failHandler:(id)failHandler;
 

--- a/TOSMBClient/TOSMBSessionUploadTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionUploadTaskPrivate.h
@@ -25,8 +25,9 @@
 #define TOSMBSessionUploadTaskPrivate_h
 
 #import "TOSMBSessionUploadTask.h"
+#import "TOSMBSessionTaskPrivate.h"
 
-@interface TOSMBSessionUploadTask ()
+@interface TOSMBSessionUploadTask () <TOSMBSessionTaskSubclass>
 
 - (instancetype)initWithSession:(TOSMBSession *)session
                            path:(NSString *)path

--- a/TOSMBClient/TOSMBSessionUploadTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionUploadTaskPrivate.h
@@ -32,6 +32,11 @@
 - (instancetype)initWithSession:(TOSMBSession *)session
                            path:(NSString *)path
                            data:(NSData *)data
+                       delegate:(id <TOSMBSessionUploadTaskDelegate>)delegate;
+
+- (instancetype)initWithSession:(TOSMBSession *)session
+                           path:(NSString *)path
+                           data:(NSData *)data
                  successHandler:(id)successHandler
                     failHandler:(id)failHandler;
 

--- a/TOSMBClient/TOSMBSessionUploadTaskPrivate.h
+++ b/TOSMBClient/TOSMBSessionUploadTaskPrivate.h
@@ -1,5 +1,5 @@
 //
-// TOSMBClient.h
+// TOSMBSessionUploadTaskPrivate.h
 // Copyright 2015-2016 Timothy Oliver
 //
 // This file is dual-licensed under both the MIT License, and the LGPL v2.1 License.
@@ -20,28 +20,14 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // -------------------------------------------------------------------------------
 
-//! Project version number for TOSMBClient.
-FOUNDATION_EXPORT double TOSMBClientVersionNumber;
 
-//! Project version string for TOSMBClient.
-FOUNDATION_EXPORT const unsigned char TOSMBClientVersionString[];
+#ifndef TOSMBSessionUploadTaskPrivate_h
+#define TOSMBSessionUploadTaskPrivate_h
 
-#import "TOSMBConstants.h"
-
-#import "TOSMBSession.h"
-#import "TOSMBSessionFile.h"
-#import "TOSMBSessionTask.h"
-#import "TOSMBSessionDownloadTask.h"
 #import "TOSMBSessionUploadTask.h"
 
-#import "TONetBIOSNameService.h"
-#import "TONetBIOSNameServiceEntry.h"
+@interface TOSMBSessionUploadTask ()
 
-#import "TOSMBConstants.h"
+@end
 
-#import "TOSMBSession.h"
-#import "TOSMBSessionFile.h"
-#import "TOSMBSessionDownloadTask.h"
-
-#import "TONetBIOSNameService.h"
-#import "TONetBIOSNameServiceEntry.h"
+#endif /* TOSMBSessionUploadTaskPrivate_h */

--- a/TOSMBClientExample/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/TOSMBClientExample/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },
@@ -32,6 +42,16 @@
     },
     {
       "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
       "size" : "29x29",
       "scale" : "1x"
     },
@@ -58,6 +78,11 @@
     {
       "idiom" : "ipad",
       "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
       "scale" : "2x"
     }
   ],

--- a/TOSMBClientExample/TOFilesTableViewController.h
+++ b/TOSMBClientExample/TOFilesTableViewController.h
@@ -10,10 +10,12 @@
 #import "TORootViewController.h"
 
 @class TOSMBSession;
+@class TOSMBSessionFile;
 
 @interface TOFilesTableViewController : UITableViewController
 
-@property (nonatomic, strong) NSArray *files;
+@property (nonatomic, copy) NSString *path;
+@property (nonatomic, strong) NSArray <TOSMBSessionFile *> *files;
 @property (nonatomic, weak) TORootViewController *rootController;
 
 - (instancetype)initWithSession:(TOSMBSession *)session title:(NSString *)title;

--- a/TOSMBClientExample/TOFilesTableViewController.m
+++ b/TOSMBClientExample/TOFilesTableViewController.m
@@ -33,6 +33,15 @@
     [super viewDidLoad];
     
     self.navigationItem.title = @"Loading...";
+    
+    if (self.path.length) {
+        UIBarButtonItem *uploadButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAdd target:self action:@selector(upload:)];
+        self.navigationItem.rightBarButtonItems = @[self.navigationItem.rightBarButtonItems.firstObject, uploadButton];
+    }
+}
+
+- (void)upload:(id)sender {
+    NSString *fileName = [NSUUID UUID].UUIDString;
 }
 
 #pragma mark - Table view data source
@@ -68,7 +77,8 @@
     
     TOFilesTableViewController *controller = [[TOFilesTableViewController alloc] initWithSession:self.session title:file.name];
     controller.rootController = self.rootController;
-    controller.navigationItem.rightBarButtonItem = self.navigationItem.rightBarButtonItem;
+    controller.path = file.filePath;
+    controller.navigationItem.rightBarButtonItems = self.navigationItem.rightBarButtonItems;
     [self.navigationController pushViewController:controller animated:YES];
     
     [self.session requestContentsOfDirectoryAtFilePath:file.filePath success:^(NSArray *files) {
@@ -79,10 +89,11 @@
     }];
 }
 
-- (void)setFiles:(NSArray *)files
+- (void)setFiles:(NSArray <TOSMBSessionFile *> *)files
 {
     _files = files;
     self.navigationItem.title = self.directoryTitle;
+    
     [self.tableView reloadData];
 }
          

--- a/TOSMBClientExample/TOFilesTableViewController.m
+++ b/TOSMBClientExample/TOFilesTableViewController.m
@@ -14,6 +14,7 @@
 
 @property (nonatomic, copy) NSString *directoryTitle;
 @property (nonatomic, strong) TOSMBSession *session;
+@property (nonatomic, strong) TOSMBSessionUploadTask *uploadTask;
 
 @end
 
@@ -41,7 +42,31 @@
 }
 
 - (void)upload:(id)sender {
-    NSString *fileName = [NSUUID UUID].UUIDString;
+    self.navigationItem.rightBarButtonItems.lastObject.enabled = NO;
+    NSString *path = [[self.path stringByAppendingPathComponent:[NSUUID UUID].UUIDString] stringByAppendingPathExtension:@"txt"];
+    NSData *data = [path dataUsingEncoding:NSUTF8StringEncoding];
+    
+    __weak typeof(self) weakSelf = self;
+    self.uploadTask = [self.session uploadTaskForFileAtPath:path data:data progressHandler:nil completionHandler:^{
+        [weakSelf reloadData];
+        weakSelf.navigationItem.rightBarButtonItems.lastObject.enabled = YES;
+    } failHandler:^(NSError *error) {
+        weakSelf.navigationItem.rightBarButtonItems.lastObject.enabled = YES;
+    }];
+    
+    [self.uploadTask resume];
+}
+
+- (void)reloadData {
+    __weak typeof(self) weakSelf = self;
+    [self.session requestContentsOfDirectoryAtFilePath:self.path success:^(NSArray *files) {
+        weakSelf.files = files;
+        [weakSelf.tableView reloadData];
+    } error:^(NSError *error) {
+        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"SMB Client Error" message:error.localizedDescription delegate:nil cancelButtonTitle:nil otherButtonTitles:@"OK", nil];
+        [alert show];
+    }];
+    
 }
 
 #pragma mark - Table view data source

--- a/TOSMBClientExample/TORootTableViewController.m
+++ b/TOSMBClientExample/TORootTableViewController.m
@@ -95,7 +95,7 @@
 
 - (void)pushContentOfRootDirectory {
     TOFilesTableViewController *controller = [[TOFilesTableViewController alloc] initWithSession:self.session title:@"Shares"];
-    controller.navigationItem.rightBarButtonItem = self.navigationItem.rightBarButtonItem;
+    controller.navigationItem.rightBarButtonItems = @[self.navigationItem.rightBarButtonItem];
     controller.rootController = self.rootController;
     [self.navigationController pushViewController:controller animated:YES];
     


### PR DESCRIPTION
This PR:
 * Refactors some of the code out of `TOSMBSessionDownloadTask` into a generic `TOSMBSessionTask`
 * Introduces `TOSMBSessionUploadTask`
 * Pulls out some of the private class extensions into their own private headers; helping keep with the theme of mimicking `NSURLSession`

Known limitations of `TOSMBSessionUploadTask`
 * Resuming uploads
 * Delegation; There are no methods to create an upload task with a delegate, only block support at the moment.